### PR TITLE
log -> logrus

### DIFF
--- a/nomad/data_source_acl_policies.go
+++ b/nomad/data_source_acl_policies.go
@@ -5,7 +5,7 @@ package nomad
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"

--- a/nomad/data_source_acl_policy.go
+++ b/nomad/data_source_acl_policy.go
@@ -5,7 +5,7 @@ package nomad
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 
 	"github.com/hashicorp/nomad/api"

--- a/nomad/data_source_acl_role.go
+++ b/nomad/data_source_acl_role.go
@@ -5,7 +5,7 @@ package nomad
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/nomad/data_source_acl_token.go
+++ b/nomad/data_source_acl_token.go
@@ -5,7 +5,7 @@ package nomad
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"time"
 

--- a/nomad/data_source_deployments.go
+++ b/nomad/data_source_deployments.go
@@ -5,7 +5,7 @@ package nomad
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strconv"
 	"strings"
 

--- a/nomad/data_source_job_parser.go
+++ b/nomad/data_source_job_parser.go
@@ -6,7 +6,7 @@ package nomad
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/nomad/data_source_namespaces.go
+++ b/nomad/data_source_namespaces.go
@@ -5,7 +5,7 @@ package nomad
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )

--- a/nomad/data_source_plugins.go
+++ b/nomad/data_source_plugins.go
@@ -5,7 +5,7 @@ package nomad
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/nomad/data_source_regions.go
+++ b/nomad/data_source_regions.go
@@ -5,7 +5,7 @@ package nomad
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )

--- a/nomad/data_source_volumes.go
+++ b/nomad/data_source_volumes.go
@@ -5,7 +5,7 @@ package nomad
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strconv"
 
 	"github.com/hashicorp/nomad/api"

--- a/nomad/datasource_nomad_job.go
+++ b/nomad/datasource_nomad_job.go
@@ -5,7 +5,7 @@ package nomad
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 
 	"github.com/hashicorp/nomad/api"

--- a/nomad/datasource_nomad_plugin.go
+++ b/nomad/datasource_nomad_plugin.go
@@ -5,7 +5,7 @@ package nomad
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 
 	"github.com/hashicorp/nomad/api"

--- a/nomad/resource_acl_policy.go
+++ b/nomad/resource_acl_policy.go
@@ -5,7 +5,7 @@ package nomad
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 
 	"github.com/hashicorp/nomad/api"

--- a/nomad/resource_acl_role.go
+++ b/nomad/resource_acl_role.go
@@ -5,7 +5,7 @@ package nomad
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 
 	"github.com/hashicorp/nomad/api"

--- a/nomad/resource_acl_token.go
+++ b/nomad/resource_acl_token.go
@@ -5,7 +5,7 @@ package nomad
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"time"
 

--- a/nomad/resource_external_volume.go
+++ b/nomad/resource_external_volume.go
@@ -8,7 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"hash/crc32"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/dustin/go-humanize"
 	"github.com/hashicorp/nomad/api"

--- a/nomad/resource_job.go
+++ b/nomad/resource_job.go
@@ -6,7 +6,7 @@ package nomad
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"sort"
 	"strconv"

--- a/nomad/resource_namespace.go
+++ b/nomad/resource_namespace.go
@@ -5,7 +5,7 @@ package nomad
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"time"
 

--- a/nomad/resource_quota_specification.go
+++ b/nomad/resource_quota_specification.go
@@ -5,7 +5,7 @@ package nomad
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 
 	"github.com/hashicorp/nomad/api"

--- a/nomad/resource_scheduler_config.go
+++ b/nomad/resource_scheduler_config.go
@@ -6,7 +6,7 @@ package nomad
 import (
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/nomad/resource_scheduler_config_test.go
+++ b/nomad/resource_scheduler_config_test.go
@@ -4,7 +4,7 @@
 package nomad
 
 import (
-	"log"
+	log "github.com/sirupsen/logrus"
 	"testing"
 
 	"github.com/hashicorp/nomad/api"

--- a/nomad/resource_sentinel_policy.go
+++ b/nomad/resource_sentinel_policy.go
@@ -5,7 +5,7 @@ package nomad
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 
 	"github.com/hashicorp/nomad/api"

--- a/nomad/resource_volume.go
+++ b/nomad/resource_volume.go
@@ -8,7 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"hash/crc32"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 
 	"github.com/hashicorp/nomad/api"


### PR DESCRIPTION
Use logrus for logging instead of standard log library

[_Created by Sourcegraph batch change `admin/use-logrus-in-terraform-providers`._](https://gcp.s0urcegraph.com/users/admin/batch-changes/use-logrus-in-terraform-providers)